### PR TITLE
1-21-rc update all except ArtsXSkills to playable state

### DIFF
--- a/AOGBreedingAddon/AOGBreedingAddon/AOGBreedingAddon.csproj
+++ b/AOGBreedingAddon/AOGBreedingAddon/AOGBreedingAddon.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-	  <OutputPath>C:\Users\Tasya\AppData\Roaming\VintagestoryData\Mods\AOGBreedingAddon</OutputPath>
+	  <OutputPath>$(APPDATA)\VintagestoryData\Mods\AOGBreedingAddon</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ArtOfCooking/ArtOfCooking.csproj
+++ b/ArtOfCooking/ArtOfCooking.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>C:\Users\Tasya\AppData\Roaming\VintagestoryData\Mods\ArtOfCooking</OutputPath>
+    <OutputPath>$(APPDATA)\VintagestoryData\Mods\ArtOfCooking</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <Reference Include="CoreOfArts">
-      <HintPath>C:\Users\Tasya\AppData\Roaming\VintagestoryData\Mods\CoreOfArts\CoreOfArts.dll</HintPath>
+      <HintPath>$(APPDATA)\VintagestoryData\Mods\CoreOfArts\CoreOfArts.dll</HintPath>
 		<Private>False</Private>
     </Reference>
     <Reference Include="VintagestoryAPI">
@@ -119,6 +119,7 @@
 </ItemGroup>
 
 <ItemGroup>
+  <Folder Include="ArtOfCooking\" />
   <Folder Include="assets\game\patches\" />
   <Folder Include="assets\game\recipes\" />
   <Folder Include="assets\game\shapes\item\" />

--- a/ArtOfCooking/BlockEntityRenderer/DoughFormRenderer.cs
+++ b/ArtOfCooking/BlockEntityRenderer/DoughFormRenderer.cs
@@ -1,12 +1,11 @@
 ﻿using ArtOfCooking.Items;
-using CoreOfArts.Systems;
 using System;
+using CoreOfArts.Systems;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
-using Vintagestory.GameContent;
 
 namespace ArtOfCooking.BlockEntityRenderer
 {

--- a/ArtOfCooking/Items/AOCItemRollingPin.cs
+++ b/ArtOfCooking/Items/AOCItemRollingPin.cs
@@ -1,19 +1,5 @@
-﻿using ArtOfCooking.BlockEntities;
-using ArtOfCooking.Blocks;
-using CoreOfArts.Systems;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Text;
-using Vintagestory.API;
-using Vintagestory.API.Client;
+﻿using Vintagestory.API.Client;
 using Vintagestory.API.Common;
-using Vintagestory.API.Common.Entities;
-using Vintagestory.API.Config;
-using Vintagestory.API.Datastructures;
-using Vintagestory.API.MathTools;
-using Vintagestory.API.Server;
-using Vintagestory.API.Util;
 using Vintagestory.GameContent;
 
 namespace ArtOfCooking.Items

--- a/ArtOfCooking/assets/artofcooking/lang/en.json
+++ b/ArtOfCooking/assets/artofcooking/lang/en.json
@@ -89,7 +89,7 @@
   "artofcooking:blockdesc-copperbowl-*": "It can no longer be used. If you still have such a bowl, you can disassemble it in the crafting grid.",
 
   "artofcooking:block-handbooktitle-metalpot": "Use",
-  "artofcooking:block-handbooktext-metalpot": "See <a href=\"handbook://craftinginfo-mealcooking\">Meal making guide</a>. You cannot eat from a cooking pot directly, you will need a <a href=\"handbook://block-bowl-fired\">bowl</a>. If you want to empty a bowl or cooking pot without eating the contents, simply toss it in some water!",
+  "artofcooking:block-handbooktext-metalpot": "See <a href=\"handbook://craftinginfo-mealcooking\">Meal making guide</a>. You cannot eat from a cooking pot directly, you will need a <a href=\"handbook://block-bowl-*-fired\">bowl</a>. If you want to empty a bowl or cooking pot without eating the contents, simply toss it in some water!",
   "artofcooking:block-handbooktext-dirtymetalpot": "A cooking pot used to cook up <a href=\"handbook://item-glueportion-pitch-hot\">glue</a> or other non-food recipes becomes caked in residue. A residue-covered cooking pot cannot be used for meal-making with food ingredients, but is still quite handy for other purposes. A copper pot can be washed by soaking in vinegar for a day.",
 
   "artofcooking:block-handbooktitle-metalbowl": "Use",

--- a/ArtOfCooking/assets/artofcooking/lang/ru.json
+++ b/ArtOfCooking/assets/artofcooking/lang/ru.json
@@ -90,7 +90,7 @@
   "artofcooking:blockdesc-copperbowl-*": "Больше нельзя использовать. Если у вас осталась такая миска, вы можете разобрать её в сетке крафта.",
 
   "artofcooking:block-handbooktitle-metalpot": "Использование",
-  "artofcooking:block-handbooktext-metalpot": "Смотрите <a href=\"handbook:\/\/craftinginfo-mealcooking\">руководство по приготовлению пищи<\/a>. Вы не можете есть непосредственно из кастрюли, для этого понадобится <a href=\"handbook:\/\/block-bowl-fired\">миска<\/a>. Если вы хотите опустошить миску или кастрюлю, не съедая содержимого, просто бросьте их в воду!",
+  "artofcooking:block-handbooktext-metalpot": "Смотрите <a href=\"handbook:\/\/craftinginfo-mealcooking\">руководство по приготовлению пищи<\/a>. Вы не можете есть непосредственно из кастрюли, для этого понадобится <a href=\"handbook:\/\/block-bowl-*-fired\">миска<\/a>. Если вы хотите опустошить миску или кастрюлю, не съедая содержимого, просто бросьте их в воду!",
   "artofcooking:block-handbooktext-dirtymetalpot": "Кастрюля, используемая для приготовления <a href=\"handbook:\/\/item-glueportion-pitch-hot\">клея<\/a> или других непищевых рецептов, становится покрыта остатками. Покрытая остатками кастрюля не может быть использована для приготовления пищи, но она вполне пригодится для других целей. Медную кастрюлю можно отмыть, замочив в уксусе на сутки.",
 
   "artofcooking:block-handbooktitle-metalbowl": "Применение",

--- a/ArtOfCooking/assets/artofcooking/recipes/grid/nutcandy.json
+++ b/ArtOfCooking/assets/artofcooking/recipes/grid/nutcandy.json
@@ -476,7 +476,7 @@
     "ingredients": {
       "K": {
         "type": "block",
-        "code": "game:bowl-fired"
+        "code": "game:bowl-{color}-fired"
       },
       "H": {
         "type": "item",

--- a/ArtOfCooking/modinfo.json
+++ b/ArtOfCooking/modinfo.json
@@ -6,9 +6,9 @@
     "Fedarmens"
   ],
   "description": "Bronze kitchen appliances. Kneading dough and shawarma.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "dependencies": {
     "game": "",
-    "coreofarts": "1.0.0"
+    "coreofarts": "1.1.0"
   }
 }

--- a/ArtOfGrowing/ArtOfGrowing.csproj
+++ b/ArtOfGrowing/ArtOfGrowing.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>C:\Users\Tasya\AppData\Roaming\VintagestoryData\Mods\ArtOfGrowing</OutputPath>
+    <OutputPath>$(APPDATA)\VintagestoryData\Mods\ArtOfGrowing</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/ArtOfGrowing/BlockBehaviors/AOGPumpkinCropBehavior.cs
+++ b/ArtOfGrowing/BlockBehaviors/AOGPumpkinCropBehavior.cs
@@ -3,7 +3,6 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
-using Vintagestory.GameContent;
 
 namespace ArtOfGrowing.BlockBehaviors
 {
@@ -31,7 +30,10 @@ namespace ArtOfGrowing.BlockBehaviors
             vineGrowthQuantityGen = properties["vineGrowthQuantity"].AsObject<NatFloat>();
             vineBlockLocation = new AssetLocation("pumpkin-vine-" + size + "-1-normal");
         }
-        public override void OnPlanted(ICoreAPI api)
+        public override void OnPlanted(ICoreAPI api,
+            ItemSlot itemslot,
+            EntityAgent byEntity,
+            BlockSelection blockSel)
         {
             vineGrowthQuantity = vineGrowthQuantityGen.nextFloat(1, api.World.Rand);
         }

--- a/ArtOfGrowing/Items/AOGItemPlantableSeed.cs
+++ b/ArtOfGrowing/Items/AOGItemPlantableSeed.cs
@@ -1,16 +1,10 @@
-using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
 using System.Text;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
-using Vintagestory.API.Datastructures;
 using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
-using Vintagestory.API.Util;
 using Vintagestory.GameContent;
-using Vintagestory.API.Common.Entities;
-using System.Drawing;
 
 namespace ArtOfGrowing.Items
 {
@@ -45,7 +39,7 @@ namespace ArtOfGrowing.Items
                 IPlayer byPlayer = null;
                 if (byEntity is EntityPlayer) byPlayer = byEntity.World.PlayerByUid(((EntityPlayer)byEntity).PlayerUID);
 
-                bool planted = ((BlockEntityFarmland)be).TryPlant(cropBlock);
+                bool planted = ((BlockEntityFarmland)be).TryPlant(cropBlock, itemslot, byEntity, blockSel);
                 if (planted)
                 {
                     byEntity.World.PlaySoundAt(new AssetLocation("sounds/block/plant"), pos, 0.4375, byPlayer);

--- a/ArtOfGrowing/Items/AOGItemSeedling.cs
+++ b/ArtOfGrowing/Items/AOGItemSeedling.cs
@@ -68,7 +68,7 @@ namespace ArtOfGrowing.Items
                             IPlayer byPlayer = null;
                             if (byEntity is EntityPlayer) byPlayer = byEntity.World.PlayerByUid(((EntityPlayer)byEntity).PlayerUID);
 
-                            bool planted = ((BlockEntityFarmland)be).TryPlant(cropBlock);
+                            bool planted = ((BlockEntityFarmland)be).TryPlant(cropBlock, itemslot, byEntity, blockSel);
                             if (planted)
                             {
                                 byEntity.World.PlaySoundAt(new AssetLocation("sounds/block/plant"), pos.X, pos.Y, pos.Z, byPlayer);

--- a/ArtOfGrowing/assets/artofgrowing/recipes/grid/flaxbundle-clear.json
+++ b/ArtOfGrowing/assets/artofgrowing/recipes/grid/flaxbundle-clear.json
@@ -34,7 +34,7 @@
     "ingredients": {
       "W": {
         "type": "block",
-        "code": "game:bowl-fired"
+        "code": "game:bowl-{color}-fired"
       },
       "F": {
         "type": "item",

--- a/ArtOfGrowing/modinfo.json
+++ b/ArtOfGrowing/modinfo.json
@@ -6,9 +6,9 @@
     "Fedarmens"
   ],
   "description": "Realistic stages of crop growth, mowing grass and haystacks.",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "dependencies": {
     "game": "",
-    "coreofarts": "0.2.0"
+    "coreofarts": "1.1.0"
   }
 }

--- a/Arts.sln.DotSettings
+++ b/Arts.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=COA/@EntryIndexedValue">COA</s:String></wpf:ResourceDictionary>

--- a/CoreOfArt/CakeBuild/CakeBuild.csproj
+++ b/CoreOfArt/CakeBuild/CakeBuild.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   

--- a/CoreOfArt/CoreOfArt/Blocks/COABlockBucket.cs
+++ b/CoreOfArt/CoreOfArt/Blocks/COABlockBucket.cs
@@ -1,11 +1,7 @@
 ﻿using CoreOfArts.Systems;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
-using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 using Vintagestory.GameContent;
 
@@ -46,30 +42,31 @@ namespace CoreOfArts.Blocks
             }
 
             return base.GetHeldInteractionHelp(inSlot).Append(
-                new WorldInteraction[]
-            {
-                new WorldInteraction()
-                {
-                    ActionLangCode = "coreofart:heldhelp-mixing",
-                    MouseButton = EnumMouseButton.Right,
-                    HotKeyCode = "ctrl",
-                    Itemstacks = stacks.ToArray(),
-                    GetMatchingStacks = (wi, bs, es) => {
-                        bool canMixing = false;
-                        foreach (var recipe in api.GetLiquidMixingRecipes())
+                [
+                    new WorldInteraction
+                    {
+                        ActionLangCode = "coreofart:heldhelp-mixing",
+                        MouseButton = EnumMouseButton.Right,
+                        HotKeyCode = "ctrl",
+                        Itemstacks = stacks.ToArray(),
+                        GetMatchingStacks = (wi, _, _) =>
                         {
-                            foreach (var ingredient in recipe.Ingredients)
+                            bool canMixing = false;
+                            foreach (var recipe in api.GetLiquidMixingRecipes())
                             {
-                                if (ingredient.ResolvedItemstack.Id == GetContent(inSlot.Itemstack)?.Id)
+                                foreach (var ingredient in recipe.Ingredients)
                                 {
-                                    canMixing = true;
+                                    if (ingredient.ResolvedItemstack.Id == GetContent(inSlot.Itemstack)?.Id)
+                                    {
+                                        canMixing = true;
+                                    }
                                 }
                             }
+
+                            return canMixing ? wi.Itemstacks : null;
                         }
-                        return canMixing ? wi.Itemstacks : null;
                     }
-                }
-            }
+                ]
             );
         }
     }

--- a/CoreOfArt/CoreOfArt/Blocks/COABlockCookingContainer.cs
+++ b/CoreOfArt/CoreOfArt/Blocks/COABlockCookingContainer.cs
@@ -1,18 +1,13 @@
 ﻿using CoreOfArts.BlockEntityRenderer;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
-using Vintagestory.API.Config;
-using Vintagestory.API.MathTools;
 using Vintagestory.GameContent;
 
 namespace CoreOfArts.Blocks
 {
     public class COABlockCookingContainer : BlockCookingContainer, IInFirepitRendererSupplier
     {  
-        new public IInFirepitRenderer GetRendererWhenInFirepit(ItemStack stack, BlockEntityFirepit firepit, bool forOutputSlot)
+        public new IInFirepitRenderer GetRendererWhenInFirepit(ItemStack stack, BlockEntityFirepit firepit, bool forOutputSlot)
         {
             return new COAPotInFirepitRenderer(api as ICoreClientAPI, stack, firepit.Pos, forOutputSlot);
         }     

--- a/CoreOfArt/CoreOfArt/CoreOfArts.csproj
+++ b/CoreOfArt/CoreOfArt/CoreOfArts.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>C:\Users\Tasya\AppData\Roaming\VintagestoryData\Mods\CoreOfArts</OutputPath>
+    <OutputPath>$(APPDATA)\VintagestoryData\Mods\CoreOfArts</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
More specifically:
- Bump projects' .NET version 7.0 -> 8.0
- Increase each affected modinfo.json's minor version component by 1
- Accommodate vanilla method signature changes (fortunately nothing transformative)
- Vanilla bowl itemcode now has a -{color}- part, affected roughly 2 recipes and 2 translations
- Very gentle cleanup of unused references. My IDE wanted to auto-refacto a lot more but I didn't let it
- Use Windows env variable %APPDATA% where applicable instead of an explicit path
  1. more collab-friendy
  2. serves author's privacy